### PR TITLE
Issue-12 SItemap generator serializer fix

### DIFF
--- a/src/X.Web.Sitemap/SitemapGenerator.cs
+++ b/src/X.Web.Sitemap/SitemapGenerator.cs
@@ -5,15 +5,15 @@ namespace X.Web.Sitemap
 {
     public class SitemapGenerator : ISitemapGenerator
     {
-        private readonly ISerializedXmlSaver<List<Url>> _serializedXmlSaver;
+        private readonly ISerializedXmlSaver<Sitemap> _serializedXmlSaver;
         public const int MaxNumberOfUrlsPerSitemap = 50000;
 
         public SitemapGenerator()
         {
-            _serializedXmlSaver = new SerializedXmlSaver<List<Url>>(new FileSystemWrapper());
+            _serializedXmlSaver = new SerializedXmlSaver<Sitemap>(new FileSystemWrapper());
         }
 
-        internal SitemapGenerator(ISerializedXmlSaver<List<Url>> serializedXmlSaver)
+        internal SitemapGenerator(ISerializedXmlSaver<Sitemap> serializedXmlSaver)
         {
             _serializedXmlSaver = serializedXmlSaver;
         }


### PR DESCRIPTION
When using SItemapGenerator the list of url is getting out as

`<ArrayOfUrl xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"> <url> ...`

instead of
`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"> <url>`