### PR TITLE
change Url.LastMod getter logic to return datetime, hours, min, sec, timezone

### DIFF
--- a/src/X.Web.Sitemap/Url.cs
+++ b/src/X.Web.Sitemap/Url.cs
@@ -21,7 +21,7 @@ namespace X.Web.Sitemap
         [XmlElement("lastmod")]
         public string LastMod
         {
-            get => TimeStamp.ToString("yyyy-MM-dd");
+            get => TimeStamp.ToString("yyyy-MM-ddTHH:mm:sszzz");
             set => TimeStamp = DateTime.Parse(value);
         }
 


### PR DESCRIPTION
I think standard now is to include hours, min, sec, timezone