### PR TITLE
Remove JetBrains.Annotations references

### DIFF
--- a/src/X.Web.Sitemap/ChangeFrequency.cs
+++ b/src/X.Web.Sitemap/ChangeFrequency.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Xml.Serialization;
-using JetBrains.Annotations;
 
 namespace X.Web.Sitemap;
 
-[PublicAPI]
 [Serializable]
 public enum ChangeFrequency
 {

--- a/src/X.Web.Sitemap/Extensions/SitemapExtension.cs
+++ b/src/X.Web.Sitemap/Extensions/SitemapExtension.cs
@@ -1,13 +1,11 @@
 using System.IO;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 
 namespace X.Web.Sitemap.Extensions;
 
 /// <summary>
 /// Provides extension methods for ISitemap.
 /// </summary>
-[PublicAPI]
 public static class SitemapExtension
 {
     /// <summary>

--- a/src/X.Web.Sitemap/Extensions/SitemapIndexExtension.cs
+++ b/src/X.Web.Sitemap/Extensions/SitemapIndexExtension.cs
@@ -1,12 +1,10 @@
 using System.IO;
-using JetBrains.Annotations;
 
 namespace X.Web.Sitemap.Extensions;
 
 /// <summary>
 /// Provides extension methods for SitemapIndex.
 /// </summary>
-[PublicAPI]
 public static class SitemapIndexExtension
 {
     /// <summary>

--- a/src/X.Web.Sitemap/Extensions/XmlDocumentExtension.cs
+++ b/src/X.Web.Sitemap/Extensions/XmlDocumentExtension.cs
@@ -1,10 +1,8 @@
 using System.IO;
 using System.Xml;
-using JetBrains.Annotations;
 
 namespace X.Web.Sitemap.Extensions;
 
-[PublicAPI]
 public static class XmlDocumentExtension
 {
     public static string ToXml(this XmlDocument document)
@@ -12,6 +10,7 @@ public static class XmlDocumentExtension
         using (var writer = new StringWriter())
         {
             document.Save(writer);
+
             return writer.ToString();
         }
     }

--- a/src/X.Web.Sitemap/FileSystemWrapper.cs
+++ b/src/X.Web.Sitemap/FileSystemWrapper.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 
 namespace X.Web.Sitemap;
 
-[PublicAPI]
 internal interface IFileSystemWrapper
 {
     /// <summary>

--- a/src/X.Web.Sitemap/Generators/SitemapGenerator.cs
+++ b/src/X.Web.Sitemap/Generators/SitemapGenerator.cs
@@ -1,11 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using JetBrains.Annotations;
 
 namespace X.Web.Sitemap;
 
-[PublicAPI]
 public interface ISitemapGenerator
 {
     /// <summary>
@@ -62,7 +60,6 @@ public class SitemapGenerator : ISitemapGenerator
     private readonly IFileSystemWrapper _fileSystemWrapper;
     private readonly ISitemapSerializer _serializer;
 
-    [PublicAPI]
     public int MaxNumberOfUrlsPerSitemap { get; set; } = Sitemap.DefaultMaxNumberOfUrlsPerSitemap;
         
     public SitemapGenerator()

--- a/src/X.Web.Sitemap/Generators/SitemapIndexGenerator.cs
+++ b/src/X.Web.Sitemap/Generators/SitemapIndexGenerator.cs
@@ -1,11 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Xml.Serialization;
-using JetBrains.Annotations;
 
 namespace X.Web.Sitemap;
 
-[PublicAPI]
 public interface ISitemapIndexGenerator
 {
 	/// <summary>
@@ -25,7 +23,6 @@ public interface ISitemapIndexGenerator
 	SitemapIndex GenerateSitemapIndex(IEnumerable<SitemapInfo> sitemaps, string targetDirectory, string targetSitemapIndexFileName);
 }
 
-[PublicAPI]
 public class SitemapIndexGenerator : ISitemapIndexGenerator
 {
 	private readonly IFileSystemWrapper _fileSystemWrapper;

--- a/src/X.Web.Sitemap/ISitemap.cs
+++ b/src/X.Web.Sitemap/ISitemap.cs
@@ -1,9 +1,7 @@
 ﻿using System.Collections.Generic;
-using JetBrains.Annotations;
 
 namespace X.Web.Sitemap;
 
-[PublicAPI]
 public interface ISitemap : IList<Url>
 {
 }

--- a/src/X.Web.Sitemap/Image.cs
+++ b/src/X.Web.Sitemap/Image.cs
@@ -1,11 +1,9 @@
 using System;
 using System.ComponentModel;
 using System.Xml.Serialization;
-using JetBrains.Annotations;
 
 namespace X.Web.Sitemap;
 
-[PublicAPI]
 [Serializable]
 [Description("Encloses all information about a single image. Each URL (<loc> tag) can include up to 1,000 <image:image> tags.")]
 [XmlRoot(ElementName = "image", Namespace = "http://www.google.com/schemas/sitemap-image/1.1")]

--- a/src/X.Web.Sitemap/Serializers/SitemapIndexSerializer.cs
+++ b/src/X.Web.Sitemap/Serializers/SitemapIndexSerializer.cs
@@ -2,11 +2,9 @@
 using System.IO;
 using System.Xml;
 using System.Xml.Serialization;
-using JetBrains.Annotations;
 
 namespace X.Web.Sitemap;
 
-[PublicAPI]
 public interface ISitemapIndexSerializer
 {
     string Serialize(SitemapIndex sitemap);

--- a/src/X.Web.Sitemap/Serializers/SitemapSerializer.cs
+++ b/src/X.Web.Sitemap/Serializers/SitemapSerializer.cs
@@ -2,11 +2,9 @@
 using System.IO;
 using System.Xml;
 using System.Xml.Serialization;
-using JetBrains.Annotations;
 
 namespace X.Web.Sitemap;
 
-[PublicAPI]
 public interface ISitemapSerializer
 {
     string Serialize(ISitemap sitemap);

--- a/src/X.Web.Sitemap/Sitemap.cs
+++ b/src/X.Web.Sitemap/Sitemap.cs
@@ -2,14 +2,12 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Xml.Serialization;
-using JetBrains.Annotations;
 
 [assembly: InternalsVisibleTo("X.Web.Sitemap.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 
 namespace X.Web.Sitemap;
 
-[PublicAPI]
 [Serializable]
 [XmlRoot(ElementName = "urlset", Namespace = "http://www.sitemaps.org/schemas/sitemap/0.9")]
 public class Sitemap : List<Url>, ISitemap
@@ -22,10 +20,8 @@ public class Sitemap : List<Url>, ISitemap
 
     public Sitemap(IEnumerable<Url> urls) => AddRange(urls);
 
-    [PublicAPI]
     public static Sitemap Parse(string xml) => new SitemapSerializer().Deserialize(xml);
 
-    [PublicAPI]
     public static bool TryParse(string xml, out Sitemap? sitemap)
     {
         try

--- a/src/X.Web.Sitemap/SitemapIndex.cs
+++ b/src/X.Web.Sitemap/SitemapIndex.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Serialization;
-using JetBrains.Annotations;
 
 namespace X.Web.Sitemap;
 
@@ -28,10 +27,8 @@ public class SitemapIndex
     [XmlElement("sitemap")]
     public List<SitemapInfo> Sitemaps { get; private set; }
     
-    [PublicAPI]
     public static SitemapIndex Parse(string xml) => new SitemapIndexSerializer().Deserialize(xml);
 
-    [PublicAPI]
     public static bool TryParse(string xml, out SitemapIndex? sitemapIndex)
     {
         try

--- a/src/X.Web.Sitemap/Url.cs
+++ b/src/X.Web.Sitemap/Url.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Xml.Serialization;
-using JetBrains.Annotations;
 
 namespace X.Web.Sitemap;
 
-[PublicAPI]
 [Serializable]
 [XmlRoot("url")]
 [XmlType("url")]

--- a/src/X.Web.Sitemap/X.Web.Sitemap.csproj
+++ b/src/X.Web.Sitemap/X.Web.Sitemap.csproj
@@ -18,8 +18,4 @@
         <None Include="../../x-web.png" Pack="True" PackagePath=""/>
     </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" PrivateAssets="All"/>
-    </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This pull request removes the dependency on JetBrains.Annotations from the `X.Web.Sitemap` project. All usages of the `[PublicAPI]` attribute and related `using JetBrains.Annotations;` statements have been eliminated from interfaces, classes, and extension methods. The corresponding NuGet package reference has also been removed from the project file.

Dependency removal:

* Deleted the `<PackageReference Include="JetBrains.Annotations" ... />` from `X.Web.Sitemap.csproj`, fully removing the JetBrains.Annotations dependency from the project.

Code cleanup:

* Removed all `[PublicAPI]` attributes from public interfaces and classes such as `ISitemap`, `ISitemapGenerator`, `ISitemapIndexGenerator`, `ISitemapSerializer`, `ISitemapIndexSerializer`, `Sitemap`, `SitemapIndex`, `Url`, `Image`, and extension classes (`SitemapExtension`, `SitemapIndexExtension`, `XmlDocumentExtension`). [[1]](diffhunk://#diff-a409868222d6cf7845978d7f83f8dc8c66a791d94c94a51a1a578ad9e93fc8c4L3-L7) [[2]](diffhunk://#diff-154c1824b393519b8dc9c8efc26052427be48eccbbc0d45aae776a36b6083742L3-L10) [[3]](diffhunk://#diff-faa6832f22a267e11ba1a59e0ea57cdc0b5652276704db1faa1bc9704d2043ddL2-L9) [[4]](diffhunk://#diff-edd67130becd3532c4a386d9ccfef962ab30ef636629839fdeeea28c0d477d91L3-R13) [[5]](diffhunk://#diff-06d3fd0cee7699d1cf66f71d50288ce71d87576650845e32eb866c210d038a7dL4-L8) [[6]](diffhunk://#diff-ec1307ad52da9c17365ae90a5e070da94f0d7b12214123ce875129fd40cb59a0L4-L8) [[7]](diffhunk://#diff-ec1307ad52da9c17365ae90a5e070da94f0d7b12214123ce875129fd40cb59a0L65) [[8]](diffhunk://#diff-db8118ae0da2c834f805827a7b79ffa0b91d37c48ada9020fd796804b8319d38L4-L8) [[9]](diffhunk://#diff-db8118ae0da2c834f805827a7b79ffa0b91d37c48ada9020fd796804b8319d38L28) [[10]](diffhunk://#diff-b6542e1c58f184e317c20dc3d11ed87fad7c1c4f3d6c32eafd38b6f2112e5beeL2-L6) [[11]](diffhunk://#diff-2d04afd5aaca839ed0e9b9981e5a119882a7a9b4560f4b48b09570a5e07e2c9bL4-L8) [[12]](diffhunk://#diff-d82a00d782193d34bba4b46b82bf88a8b8c32e615555d945d458896c748965a7L5-L9) [[13]](diffhunk://#diff-a5f590439475e539481eb3a4632e3e2f4a4c903285e8b7c675e7793ce7e3206aL5-L9) [[14]](diffhunk://#diff-67689f1b7bed8f7c9370d88980e70563bf77f45ac8c505de2b7ff7924ae0a6b2L5-L12) [[15]](diffhunk://#diff-67689f1b7bed8f7c9370d88980e70563bf77f45ac8c505de2b7ff7924ae0a6b2L25-L28) [[16]](diffhunk://#diff-850ef0df9693d3f3f969daf4e62a43255e8f585ee71c87964ad7d6c234c6294eL5) [[17]](diffhunk://#diff-850ef0df9693d3f3f969daf4e62a43255e8f585ee71c87964ad7d6c234c6294eL31-L34) [[18]](diffhunk://#diff-dc54b127e33bbcbaad4b57b8c11dfa318b524561e1183999b010cfb74e32def3L4-L8)

* Removed all `using JetBrains.Annotations;` statements from affected files. [[1]](diffhunk://#diff-a409868222d6cf7845978d7f83f8dc8c66a791d94c94a51a1a578ad9e93fc8c4L3-L7) [[2]](diffhunk://#diff-154c1824b393519b8dc9c8efc26052427be48eccbbc0d45aae776a36b6083742L3-L10) [[3]](diffhunk://#diff-faa6832f22a267e11ba1a59e0ea57cdc0b5652276704db1faa1bc9704d2043ddL2-L9) [[4]](diffhunk://#diff-edd67130becd3532c4a386d9ccfef962ab30ef636629839fdeeea28c0d477d91L3-R13) [[5]](diffhunk://#diff-06d3fd0cee7699d1cf66f71d50288ce71d87576650845e32eb866c210d038a7dL4-L8) [[6]](diffhunk://#diff-ec1307ad52da9c17365ae90a5e070da94f0d7b12214123ce875129fd40cb59a0L4-L8) [[7]](diffhunk://#diff-db8118ae0da2c834f805827a7b79ffa0b91d37c48ada9020fd796804b8319d38L4-L8) [[8]](diffhunk://#diff-b6542e1c58f184e317c20dc3d11ed87fad7c1c4f3d6c32eafd38b6f2112e5beeL2-L6) [[9]](diffhunk://#diff-2d04afd5aaca839ed0e9b9981e5a119882a7a9b4560f4b48b09570a5e07e2c9bL4-L8) [[10]](diffhunk://#diff-d82a00d782193d34bba4b46b82bf88a8b8c32e615555d945d458896c748965a7L5-L9) [[11]](diffhunk://#diff-a5f590439475e539481eb3a4632e3e2f4a4c903285e8b7c675e7793ce7e3206aL5-L9) [[12]](diffhunk://#diff-67689f1b7bed8f7c9370d88980e70563bf77f45ac8c505de2b7ff7924ae0a6b2L5-L12) [[13]](diffhunk://#diff-850ef0df9693d3f3f969daf4e62a43255e8f585ee71c87964ad7d6c234c6294eL5) [[14]](diffhunk://#diff-dc54b127e33bbcbaad4b57b8c11dfa318b524561e1183999b010cfb74e32def3L4-L8)

These changes simplify the codebase and reduce external dependencies, making maintenance and distribution easier.…he project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal code annotations from the library. No changes to functionality or behavior—all public APIs remain intact and unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->